### PR TITLE
Swift 5.0 compatibility

### DIFF
--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = DB6ADF151C23610B00D77BF1;
@@ -734,6 +735,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF801C23617500D77BF1 /* Debug.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -741,6 +743,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF821C23617500D77BF1 /* Release.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -749,6 +752,7 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -759,6 +763,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -769,6 +774,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -778,6 +784,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -786,6 +793,7 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -795,6 +803,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -804,7 +813,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -814,7 +823,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -823,6 +832,7 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -833,6 +843,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -843,6 +854,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -852,6 +864,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = Tests/FreddyTests/Info.plist;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -860,6 +873,7 @@
 			baseConfigurationReference = DB6ADF811C23617500D77BF1 /* Framework.xcconfig */;
 			buildSettings = {
 				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -870,6 +884,7 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Big Nerd Ranch";
 				TargetAttributes = {
 					DB6ADF1E1C23610B00D77BF1 = {
@@ -735,6 +735,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF801C23617500D77BF1 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -743,6 +744,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB6ADF821C23617500D77BF1 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Freddy.xcodeproj/project.pbxproj
+++ b/Freddy.xcodeproj/project.pbxproj
@@ -506,11 +506,11 @@
 			};
 			buildConfigurationList = DB6ADF191C23610B00D77BF1 /* Build configuration list for PBXProject "Freddy" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = DB6ADF151C23610B00D77BF1;
 			productRefGroup = DB6ADF201C23610B00D77BF1 /* Products */;

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/Freddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/MobileFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/NanoFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
+++ b/Freddy.xcodeproj/xcshareddata/xcschemes/TVFreddy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/JSONDecodable.swift
+++ b/Sources/JSONDecodable.swift
@@ -52,7 +52,7 @@ extension Int: JSONDecodable {
         if let int = Int(string) {
             self = int
         } else if let double = Double(string),
-            let decimalSeparator = characters.index(of: "."),
+            let decimalSeparator = characters.firstIndex(of: "."),
             let int = Int(String(characters.prefix(upTo: decimalSeparator))),
             double == Double(int) {
             self = int

--- a/Sources/JSONParser.swift
+++ b/Sources/JSONParser.swift
@@ -820,8 +820,9 @@ public extension JSONParser {
 
     /// Creates an instance of `JSON` from UTF-8 encoded `data`.
     static func parse(utf8 data: Data) throws -> JSON {
-        return try data.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> JSON in
-            let buffer = UnsafeBufferPointer(start: ptr, count: data.count)
+        return try data.withUnsafeBytes { ptr -> JSON in
+            let buffer = UnsafeBufferPointer(start: ptr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                                             count: data.count)
             var parser = JSONParser(input: buffer)
             return try parser.parse()
         }

--- a/Tests/FreddyTests/JSONSerializingTests.swift
+++ b/Tests/FreddyTests/JSONSerializingTests.swift
@@ -5,7 +5,6 @@ import Freddy
 
 class JSONSerializingTests: XCTestCase {
     let json = JSONFromFixture("sample.JSON")
-    let noWhiteSpaceData = dataFromFixture("sampleNoWhiteSpace.JSON")
 
     func testThatJSONCanBeSerializedToNSData() {
         let data = try! json.serialize()
@@ -17,18 +16,9 @@ class JSONSerializingTests: XCTestCase {
         XCTAssertFalse(string.isEmpty, "There should be characters.")
     }
 
-    func testThatJSONDataIsEqual() {
-        let serializedJSONData = try! json.serialize()
-        let noWhiteSpaceJSON = try! JSON(data: noWhiteSpaceData)
-        let noWhiteSpaceSerializedJSONData = try! noWhiteSpaceJSON.serialize()
-        XCTAssertEqual(serializedJSONData, noWhiteSpaceSerializedJSONData, "Serialized data should be equal.")
-    }
-    
-    func testThatJSONStringIsEqual() {
-        let serializedJSONString = try! json.serializeString()
-        let noWhiteSpaceJSON = try! JSON(data: noWhiteSpaceData)
-        let noWhiteSpaceSerializedJSONString = try! noWhiteSpaceJSON.serializeString()
-        XCTAssertEqual(serializedJSONString, noWhiteSpaceSerializedJSONString, "Serialized string should be equal.")
+    func testThatNoWhitespaceJSONIsEqualToJSON() {
+        let noWhiteSpaceJSON = JSONFromFixture("sampleNoWhiteSpace.JSON")
+        XCTAssertEqual(json, noWhiteSpaceJSON, "The JSON values should be equal.")
     }
 
     func testThatJSONDataSerializationMakesEqualJSON() {


### PR DESCRIPTION
- Adds Swift 5.0 compatibility (via Xcode 10.2)
- Migrates project file to use recommended settings.
    - Including migrating the Localisation settings away from deprecated values.
- Removes method deprecation warnings when finding character indices in strings and initialising an `UnsafeBufferPointer`.
- Refactors unit tests based on `Dictionary` hash seed changes in Swift 5.0.